### PR TITLE
Latest Plasma version merge

### DIFF
--- a/eastwood/plasma.py
+++ b/eastwood/plasma.py
@@ -51,7 +51,7 @@ class _ZStandardParallelCompressionInterface(object):
 	def __init__(self, nodes: int = cpu_count(), target_speed_ms: int = 200):
 		self.nodes = nodes
 		self.__target_speed = target_speed_ms
-		self.__average_time = deque([0], maxlen=8)
+		self.__average_time = deque([0], maxlen=128)
 		
 		self.last_level = self.__MAX_LEVEL
 		self.__global_level = self.__MAX_LEVEL

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ six==1.12.0
 Twisted==19.7.0
 zope.interface==4.6.0
 psutil==5.6.3
-zstd==1.4.1.0
+zstandard=0.11.1
 toml==0.10.0
 pycryptodome==3.9.0


### PR DESCRIPTION
A new experimental version of the ParallelCompressionInterface object has been created, called `_ZStandardParallelCompressionInterface`.

This new version has a specific dependency on `zstandard`, which means the following commands will have to be executed in order to use it without any issues:
```
pip3 uninstall zstd
pip3 install zstandard
```

This new system ought to do the following:
- Fix the segmentation fault issues caused by the previous ParallelCompressionInterface
- Offload more of the work onto C libraries
- Allow for future utilization of zstandard's dictionary training abilities [More info here](https://pypi.org/project/zstandard/)
- Allow for potentially more stable code in general